### PR TITLE
Suppress Flask development server warnings in server scripts

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -140,6 +140,11 @@ def start_flask_server():
         print("⏹️  Press Ctrl+C to stop both servers")
         print()
 
+        # Suppress Flask's development server warning
+        import logging
+        log = logging.getLogger('werkzeug')
+        log.setLevel(logging.ERROR)
+
         app.run(debug=True, host='0.0.0.0', port=5000, use_reloader=False)
 
     except Exception as e:

--- a/start_web_app.py
+++ b/start_web_app.py
@@ -111,6 +111,11 @@ def start_flask_server():
         print("⏹️  Press Ctrl+C to stop the server")
         print()
 
+        # Suppress Flask's development server warning
+        import logging
+        log = logging.getLogger('werkzeug')
+        log.setLevel(logging.ERROR)
+
         app.run(debug=False, host='0.0.0.0', port=5000)
 
     except Exception as e:

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -65,12 +65,13 @@ module.exports = (env, argv) => {
       compress: true,
       port: 3000,
       hot: true,
-      proxy: {
-        '/api': {
+      proxy: [
+        {
+          context: ['/api'],
           target: 'http://localhost:5000',
           changeOrigin: true,
         },
-      },
+      ],
     },
     optimization: {
       splitChunks: {

--- a/web_app.py
+++ b/web_app.py
@@ -55,4 +55,9 @@ def serve_static(filename):
         return serve_index()
 
 if __name__ == '__main__':
+    # Suppress Flask's development server warning
+    import logging
+    log = logging.getLogger('werkzeug')
+    log.setLevel(logging.ERROR)
+
     app.run(debug=False, host='0.0.0.0', port=5000)  # Disable auto-reload temporarily for debugging


### PR DESCRIPTION
- Added logging configuration to suppress warnings from the Werkzeug server in `dev_server.py`, `start_web_app.py`, and `web_app.py` for a cleaner output during development.