### PR TITLE
Auto-recreate stale venv in start_ui.sh

### DIFF
--- a/start_ui.sh
+++ b/start_ui.sh
@@ -45,6 +45,18 @@ check_dependencies() {
     # Activate virtual environment
     source venv/bin/activate
 
+    # Detect stale venv (created by a different user — hardcoded paths won't match)
+    VENV_PYTHON=$(python3 -c "import sys; print(sys.prefix)" 2>/dev/null || echo "")
+    EXPECTED_PREFIX="$(pwd)/venv"
+    if [[ "$VENV_PYTHON" != "$EXPECTED_PREFIX" ]]; then
+        echo -e "${YELLOW}⚠️  Virtual environment has stale paths (was it created by another user?). Recreating...${NC}"
+        deactivate 2>/dev/null || true
+        rm -rf venv
+        python3 -m venv venv
+        source venv/bin/activate
+        pip install -r requirements.txt
+    fi
+
     # Check yt-dlp version
     if command -v pip &> /dev/null; then
         YTDLP_VERSION=$(pip show yt-dlp 2>/dev/null | grep Version | cut -d' ' -f2 || echo "not_installed")


### PR DESCRIPTION
## Summary
- Detects when the venv was created by a different user (stale hardcoded paths)
- Automatically deletes and recreates the venv, then reinstalls dependencies
- Prevents the `ModuleNotFoundError: No module named 'pip'` error on first run

## Test plan
- [ ] Run `./start_ui.sh` with a venv created by another user — should auto-recreate it
- [ ] Run `./start_ui.sh` with a valid venv — should proceed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced virtual environment validation during startup. The setup process now automatically detects when the virtual environment configuration is invalid or stale and will recreate it with fresh dependencies, ensuring a clean and functional environment state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->