### PR TITLE
fix: resolve ruff lint failures blocking CI

### DIFF
--- a/api/downloads.py
+++ b/api/downloads.py
@@ -51,7 +51,7 @@ def download_video():
 
         # Generate unique download ID and initialize
         download_id = generate_download_id()
-        main_logger.info(f"=== NEW SINGLE VIDEO DOWNLOAD ===")
+        main_logger.info("=== NEW SINGLE VIDEO DOWNLOAD ===")
         main_logger.info(f"Download ID: {download_id}")
         main_logger.info(f"URL: {url}")
         main_logger.info(f"Output dir: {output_dir}")
@@ -61,11 +61,9 @@ def download_video():
 
         initialize_download(download_id, url, output_dir, 'single')
 
-                # Start download in background thread
-        logger = get_download_logger(download_id)
-
+        # Start download in background thread
         def download_task():
-            logger = get_download_logger(download_id)
+            get_download_logger(download_id)
             try:
                 # Create custom progress hook for this download
                 custom_progress_hook = create_progress_hook(download_id)
@@ -149,7 +147,7 @@ def download_playlist_endpoint():
 
         # Generate unique download ID and initialize
         download_id = generate_download_id()
-        main_logger.info(f"=== NEW PLAYLIST DOWNLOAD ===")
+        main_logger.info("=== NEW PLAYLIST DOWNLOAD ===")
         main_logger.info(f"Download ID: {download_id}")
         main_logger.info(f"URL: {url}")
         main_logger.info(f"Start index: {start_index}, End index: {end_index}")
@@ -158,7 +156,7 @@ def download_playlist_endpoint():
 
         # Start download in background thread
         def download_task():
-            logger = get_download_logger(download_id)
+            get_download_logger(download_id)
             try:
 
                 # Update progress

--- a/api/logging_utils.py
+++ b/api/logging_utils.py
@@ -4,7 +4,6 @@ Provides centralized logging configuration and per-download loggers
 """
 
 import logging
-import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict
@@ -141,7 +140,7 @@ def log_download_error(download_id: str, error: Exception, context: str = None):
         logger.error(f"Error: {str(error)}")
 
     # Log the full traceback at debug level
-    logger.debug(f"Full traceback:", exc_info=True)
+    logger.debug("Full traceback:", exc_info=True)
 
 
 # Initialize main logger when module is imported

--- a/api/shared.py
+++ b/api/shared.py
@@ -6,7 +6,7 @@ import time
 import queue
 import uuid
 from typing import Dict, Any, Callable
-from .logging_utils import main_logger, log_download_progress, get_download_logger
+from .logging_utils import main_logger, get_download_logger
 
 # Global storage for download progress and queues
 download_progress: Dict[str, Dict[str, Any]] = {}

--- a/dev_server.py
+++ b/dev_server.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 import sys
 import time
-import threading
 from pathlib import Path
 
 def check_dependencies():
@@ -17,8 +16,8 @@ def check_dependencies():
 
     # Check Python dependencies
     try:
-        import flask
-        import flask_cors
+        import flask  # noqa: F401
+        import flask_cors  # noqa: F401
         print("✅ Python dependencies OK")
     except ImportError as e:
         print(f"❌ Missing Python dependency: {e}")

--- a/start_web_app.py
+++ b/start_web_app.py
@@ -7,7 +7,6 @@ Builds the frontend and starts the Flask server
 import os
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 def check_dependencies():
@@ -16,8 +15,8 @@ def check_dependencies():
 
     # Check Python dependencies
     try:
-        import flask
-        import flask_cors
+        import flask  # noqa: F401
+        import flask_cors  # noqa: F401
         print("✅ Python dependencies OK")
     except ImportError as e:
         print(f"❌ Missing Python dependency: {e}")

--- a/test_installation.py
+++ b/test_installation.py
@@ -6,28 +6,28 @@ Test script to verify YouTube Audio Extractor installation
 def test_imports():
     """Test if all required packages can be imported."""
     try:
-        import yt_dlp
+        import yt_dlp  # noqa: F401
         print("✅ yt-dlp imported successfully")
     except ImportError as e:
         print(f"❌ Failed to import yt-dlp: {e}")
         return False
 
     try:
-        import click
+        import click  # noqa: F401
         print("✅ click imported successfully")
     except ImportError as e:
         print(f"❌ Failed to import click: {e}")
         return False
 
     try:
-        import requests
+        import requests  # noqa: F401
         print("✅ requests imported successfully")
     except ImportError as e:
         print(f"❌ Failed to import requests: {e}")
         return False
 
     try:
-        import tqdm
+        import tqdm  # noqa: F401
         print("✅ tqdm imported successfully")
     except ImportError as e:
         print(f"❌ Failed to import tqdm: {e}")
@@ -38,7 +38,6 @@ def test_imports():
 
 def test_ffmpeg():
     """Test if FFmpeg is available in the system."""
-    import subprocess
     import shutil
 
     if shutil.which('ffmpeg'):
@@ -53,7 +52,7 @@ def test_ffmpeg():
 def test_main_script():
     """Test if the main script can be imported."""
     try:
-        import youtube_audio_extractor
+        import youtube_audio_extractor  # noqa: F401
         print("✅ youtube_audio_extractor module imported successfully")
         return True
     except ImportError as e:

--- a/test_progress.py
+++ b/test_progress.py
@@ -4,8 +4,6 @@ Test script for the progress tracking functionality
 """
 
 import time
-import threading
-from youtube_audio_extractor.core import download_audio_with_progress
 
 def test_progress_hook(data):
     """Test progress hook function"""

--- a/web_app.py
+++ b/web_app.py
@@ -4,7 +4,6 @@ Flask web application for YouTube Audio Extractor
 Provides a REST API for the web UI
 """
 
-import os
 from pathlib import Path
 from flask import Flask, send_from_directory, send_file
 from flask_cors import CORS

--- a/youtube_audio_extractor.py
+++ b/youtube_audio_extractor.py
@@ -5,7 +5,6 @@ A command-line tool to extract audio from YouTube videos.
 """
 
 import os
-import sys
 import click
 import yt_dlp
 from pathlib import Path
@@ -130,7 +129,7 @@ def download_audio(url, output_dir="downloads", format_id=None, quality="best", 
     # Configure yt-dlp options
     ydl_opts = {
         'outtmpl': os.path.join(output_dir, '%(title)s.%(ext)s'),
-        'format': f'bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio' if format_id is None else format_id,
+        'format': 'bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio' if format_id is None else format_id,
         'postprocessors': [{
             'key': 'FFmpegExtractAudio',
             'preferredcodec': 'mp3',
@@ -146,7 +145,7 @@ def download_audio(url, output_dir="downloads", format_id=None, quality="best", 
         click.echo(f"📁 Output directory: {output_dir}")
         click.echo(f"🎚️  Audio quality: {bitrate} kbps")
         if split_large_files:
-            click.echo(f"✂️  Large file splitting: Enabled (max 16MB per chunk)")
+            click.echo("✂️  Large file splitting: Enabled (max 16MB per chunk)")
 
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             ydl.download([url])

--- a/youtube_audio_extractor/core.py
+++ b/youtube_audio_extractor/core.py
@@ -65,7 +65,7 @@ def download_audio_with_progress(url, output_dir="downloads", format_id=None, qu
     # Configure yt-dlp options
     ydl_opts = {
         'outtmpl': os.path.join(final_output_dir, '%(title)s.%(ext)s'),
-        'format': f'bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio' if format_id is None else format_id,
+        'format': 'bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio' if format_id is None else format_id,
         'postprocessors': [{
             'key': 'FFmpegExtractAudio',
             'preferredcodec': 'mp3',
@@ -99,13 +99,13 @@ def download_audio_with_progress(url, output_dir="downloads", format_id=None, qu
             if progress_hook:
                 progress_hook({'status': 'info', 'message': 'Large file splitting: Enabled (max 16MB per chunk)'})
             else:
-                click.echo(f"✂️  Large file splitting: Enabled (max 16MB per chunk)")
+                click.echo("✂️  Large file splitting: Enabled (max 16MB per chunk)")
 
         if split_by_chapters:
             if progress_hook:
                 progress_hook({'status': 'info', 'message': 'Chapter-based splitting: Enabled'})
             else:
-                click.echo(f"📚  Chapter-based splitting: Enabled")
+                click.echo("📚  Chapter-based splitting: Enabled")
             # Check if video has chapters before downloading
             if not has_chapters(url):
                 if progress_hook:

--- a/youtube_audio_extractor/playlists.py
+++ b/youtube_audio_extractor/playlists.py
@@ -106,10 +106,10 @@ def download_playlist(url, output_dir="downloads", quality="best", bitrate="192"
     click.echo(f"🎚️  Audio quality: {bitrate} kbps")
 
     if split_large_files:
-        click.echo(f"✂️  Large file splitting: Enabled (max 16MB per chunk)")
+        click.echo("✂️  Large file splitting: Enabled (max 16MB per chunk)")
 
     if split_by_chapters:
-        click.echo(f"📚  Chapter-based splitting: Enabled")
+        click.echo("📚  Chapter-based splitting: Enabled")
 
     # Determine range of videos to download
     total_videos = len(entries)
@@ -148,7 +148,7 @@ def download_playlist(url, output_dir="downloads", quality="best", bitrate="192"
             click.echo(f"❌ [{i}/{end_idx}] Failed to download: {video_title}")
 
     # Summary
-    click.echo(f"\n🎯 Download completed!")
+    click.echo("\n🎯 Download completed!")
     click.echo(f"✅ Successful: {successful_downloads}")
     click.echo(f"❌ Failed: {failed_downloads}")
     click.echo(f"📁 All files saved to: {playlist_dir}")
@@ -195,13 +195,13 @@ def download_playlist_with_progress(url, output_dir="downloads", quality="best",
         if progress_hook:
             progress_hook({'status': 'info', 'message': 'Large file splitting: Enabled (max 16MB per chunk)'})
         else:
-            click.echo(f"✂️  Large file splitting: Enabled (max 16MB per chunk)")
+            click.echo("✂️  Large file splitting: Enabled (max 16MB per chunk)")
 
     if split_by_chapters:
         if progress_hook:
             progress_hook({'status': 'info', 'message': 'Chapter-based splitting: Enabled'})
         else:
-            click.echo(f"📚  Chapter-based splitting: Enabled")
+            click.echo("📚  Chapter-based splitting: Enabled")
 
     # Determine range of videos to download
     total_videos = len(entries)
@@ -283,7 +283,7 @@ def download_playlist_with_progress(url, output_dir="downloads", quality="best",
             'output_dir': str(playlist_dir)
         })
     else:
-        click.echo(f"\n🎯 Download completed!")
+        click.echo("\n🎯 Download completed!")
         click.echo(f"✅ Successful: {successful_downloads}")
         click.echo(f"❌ Failed: {failed_downloads}")
         click.echo(f"📁 All files saved to: {playlist_dir}")
@@ -297,7 +297,7 @@ def download_playlist_video(url, output_dir, quality, bitrate, split_large_files
         # Configure yt-dlp options for this video
         ydl_opts = {
             'outtmpl': os.path.join(output_dir, '%(title)s.%(ext)s'),
-            'format': f'bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio' if quality == "best" else quality,
+            'format': 'bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio' if quality == "best" else quality,
             'postprocessors': [{
                 'key': 'FFmpegExtractAudio',
                 'preferredcodec': 'mp3',
@@ -326,9 +326,9 @@ def download_playlist_video(url, output_dir, quality, bitrate, split_large_files
                     # Remove original file after successful chapter splitting
                     downloaded_file.unlink()
                 else:
-                    click.echo(f"⚠️  Chapter splitting failed for video")
+                    click.echo("⚠️  Chapter splitting failed for video")
             else:
-                click.echo(f"ℹ️  No chapters found, keeping original file")
+                click.echo("ℹ️  No chapters found, keeping original file")
 
         # Handle size-based splitting (if requested and not already handled by chapters)
         elif split_large_files and file_size_mb > 16:
@@ -336,7 +336,7 @@ def download_playlist_video(url, output_dir, quality, bitrate, split_large_files
                 # Remove original file after successful splitting
                 downloaded_file.unlink()
             else:
-                click.echo(f"⚠️  File splitting failed for video")
+                click.echo("⚠️  File splitting failed for video")
 
         return True
 
@@ -351,7 +351,7 @@ def download_playlist_video_with_progress(url, output_dir, quality, bitrate, spl
         # Configure yt-dlp options for this video
         ydl_opts = {
             'outtmpl': os.path.join(output_dir, '%(title)s.%(ext)s'),
-            'format': f'bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio' if quality == "best" else quality,
+            'format': 'bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio' if quality == "best" else quality,
             'postprocessors': [{
                 'key': 'FFmpegExtractAudio',
                 'preferredcodec': 'mp3',
@@ -389,12 +389,12 @@ def download_playlist_video_with_progress(url, output_dir, quality, bitrate, spl
                     if progress_hook:
                         progress_hook({'status': 'warning', 'message': 'Chapter splitting failed for video'})
                     else:
-                        click.echo(f"⚠️  Chapter splitting failed for video")
+                        click.echo("⚠️  Chapter splitting failed for video")
             else:
                 if progress_hook:
                     progress_hook({'status': 'info', 'message': 'No chapters found, keeping original file'})
                 else:
-                    click.echo(f"ℹ️  No chapters found, keeping original file")
+                    click.echo("ℹ️  No chapters found, keeping original file")
 
         # Handle size-based splitting (if requested and not already handled by chapters)
         elif split_large_files and file_size_mb > 16:
@@ -407,7 +407,7 @@ def download_playlist_video_with_progress(url, output_dir, quality, bitrate, spl
                 if progress_hook:
                     progress_hook({'status': 'warning', 'message': 'File splitting failed for video'})
                 else:
-                    click.echo(f"⚠️  File splitting failed for video")
+                    click.echo("⚠️  File splitting failed for video")
 
         return True
 
@@ -483,5 +483,5 @@ def list_playlist_videos(url):
         # Check if video has chapters
         video_url = entry.get('url')
         if video_url and has_chapters(video_url):
-            click.echo(f"     📚 Has chapters")
+            click.echo("     📚 Has chapters")
         click.echo()


### PR DESCRIPTION
## Summary
- Remove unused f-string prefixes (F541), unused imports (F401), and unused variable assignments (F841) flagged by ruff
- Add `# noqa: F401` to intentional try/except availability-check imports in `dev_server.py`, `start_web_app.py`, and `test_installation.py`
- Fix misindented comment and remove orphaned `logger` assignment in `api/downloads.py`

## Root cause
CI runs `ruff check .` which found 44 lint errors. The `--fix` option automatically resolved 32; the remaining 12 required manual fixes (F841 unused assignments, and F401 on try/except availability checks that are intentional).

## Test plan
- [x] `ruff check .` passes locally with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)