### PR TITLE
fix: add Docker Buildx setup to enable GHA cache in publish workflow

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v3
         with:


### PR DESCRIPTION
Root cause: The publish-container workflow used `cache-from: type=gha` and `cache-to: type=gha,mode=max` but the default Docker driver does not support cache export. Error: `Cache export is not supported for the docker driver.`

Fix: Added `docker/setup-buildx-action@v3` step before the login step, which switches to a BuildKit-backed builder that supports GitHub Actions cache export/import.